### PR TITLE
added api_post methode for retrieving sensitive data

### DIFF
--- a/dvlssdk/ApiManager.py
+++ b/dvlssdk/ApiManager.py
@@ -232,7 +232,7 @@ class ApiManager(object):
         return requests.get(uri, headers=self.DvlsRequestHeaders)
 
     def _do_api_post(self, uri):
-        return requests.get(uri, headers=self.DvlsRequestHeaders)
+        return requests.post(uri, headers=self.DvlsRequestHeaders)
 
     def _do_api_post_json(self, uri, body):
         hdrs = self.DvlsRequestHeaders

--- a/dvlssdk/ApiManager.py
+++ b/dvlssdk/ApiManager.py
@@ -205,7 +205,7 @@ class ApiManager(object):
         return SDKResult(web_request.json())
 
     def get_sensitive_data(self, connection_id, verbose_override=None):
-        web_request = self._do_api_get(self.url_resolver.get_sensitive_data(connection_id))
+        web_request = self._do_api_post(self.url_resolver.get_sensitive_data(connection_id))
         result = SDKResult(web_request.json())
         if result.success:
             data = self.EncryptionManager.aes_decrypt(result.data).decode('utf-8')
@@ -229,6 +229,9 @@ class ApiManager(object):
         return SDKResult(web_request.json())
 
     def _do_api_get(self, uri):
+        return requests.get(uri, headers=self.DvlsRequestHeaders)
+
+    def _do_api_post(self, uri):
         return requests.get(uri, headers=self.DvlsRequestHeaders)
 
     def _do_api_post_json(self, uri, body):


### PR DESCRIPTION
Because the retrieving of sensitive data was failing, I researched into the problem. I found that the REST api endpoint for sensitive data doesn't support GET request, the only allowed request is POST.
I added an _do_api_post function, and changed the web_request for sensitive data to use this POST request.

